### PR TITLE
Disable translations upload

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -16,7 +16,7 @@ jobs:
         uses: crowdin/github-action@1.4.9
         with:
           upload_sources: true
-          upload_translations: true
+          upload_translations: false
           download_translations: true
           push_translations: true
           localization_branch_name: l10n_crowdin_action


### PR DESCRIPTION
Crowdin translations upload process to HTML-based files is based on ML technology and sometimes it's not guessing the correct source <> translation pair. I used the [Document Aligner](https://store.crowdin.com/aligner) app to create a TM and then manually aligned the segments that were matched incorrectly. Then Uploaded this TM to Crowdin and made a Pre-Translate for the [project](https://crowdin.com/project/nodejs-cli-apps-best-practices). Now it looks good.

Now we can to disable translations upload from the repo to Crowdin.