### PR TITLE
Add reference to built-in styleText from node:util

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ A colorful display in your command line application output may further contribut
 
 Reference to Open Source Node.js packages:
 
+- [built-in `{ styleText } from 'node:util'`](https://nodejs.org/api/util.html#utilstyletextformat-text-options)
 - [chalk](https://www.npmjs.com/package/chalk)
 - [colors](https://www.npmjs.com/package/colors)
 - [kleur](https://www.npmjs.com/package/kleur)


### PR DESCRIPTION
As node.js has this built-in now, why use a package? 😄 