### PR TITLE
Add Node's built-in `parseArgs` to 1.1 recommended packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Command line power-users will expect your command line application to have simil
 
 Reference to Open Source Node.js packages:
 
+- [built-in `{ parseArgs } from 'node:util'`](https://nodejs.org/api/util.html#utilparseargsconfig)
 - [commander](https://github.com/tj/commander.js#readme)
 - [yargs](https://github.com/yargs/yargs)
 - [Optique](https://optique.dev/)


### PR DESCRIPTION
Node has a built-in utility that some people might not be aware  of. Recommending the built-in function over a dependency helps to satisfy recommendation 2.1.